### PR TITLE
Merge pull request #19 from nicuch/patch-1

### DIFF
--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -9,4 +9,4 @@ api-version: 1.13
 commands:
   blockparticle:
     description: Adds particles to blocks!
-    aliases: [blockparticles,bp, bparticle, bparticles]
+    aliases: [blockparticles, bp, bparticle, bparticles]


### PR DESCRIPTION
If you have multiple plugins having the same command "bp", the command "blockparticles" and aliases will not work because of this. (You can test it with Minepacks plugin that have that command for backpack).